### PR TITLE
feat: support `poem-openapi`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-xx-xx
+## [Unreleased] - 2023-xx-xx
 ### Added
 
 ### Changed
+
+## [v1.0.0-beta.2] - 2023-04-02
+### Added
+- Support of `poem-openapi` #3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poem-grants"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 authors = ["DDtKey <ddttkey@gmail.com>"]
 description = " Authorization extension for `poem` to validate user permissions "
 repository = "https://github.com/DDtKey/poem-grants"
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["poem", "authz", "security", "grants", "permissions"]
 categories = ["authentication"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "poem_grants"
@@ -21,10 +21,11 @@ macro-check = ["poem-grants-proc-macro"]
 
 [dependencies]
 poem = "1"
-poem-grants-proc-macro = { path = "./proc-macro", version = "1.0.0-beta.1", optional = true }
+poem-grants-proc-macro = { path = "./proc-macro", version = "1.0.0-beta.2", optional = true }
 thiserror = "1"
 
 [dev-dependencies]
 poem = {version = "1", features = ["test"]}
+poem-openapi = "2.0.26"
 serde = {version = "1.0", features = ["derive"]}
 tokio = {version = "1", features = ["rt-multi-thread"]}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The library can also be integrated with third-party solutions or your custom mid
 
 Provides a complete analogue of the [`actix-web-grants`].
 
-**NOTE**: [`poem-openapi`] support is still in development.
+**NOTE**: Even under `beta` flag it's ready-to-use library. However, I'm going to prepare large update of whole `*-grants` ecosystem with additional features soon. 
 
 
 ## How to use
@@ -50,8 +50,26 @@ Route::new()
 use poem::{Response, http::StatusCode};
 
 #[poem_grants::has_permissions("OP_READ_SECURED_INFO")]
+#[poem::handler]
 async fn macro_secured() -> Response {
     Response::builder().status(StatusCode::OK).body("ADMIN_RESPONSE")
+}
+```
+
+Or for `poem-openapi`:
+```rust,no_run
+use poem_openapi::{OpenApi, payload::PlainText};
+
+struct Api;
+
+#[poem_grants::open_api] // It's important to keep above of `OpenApi`
+#[OpenApi]
+impl Api {
+    #[has_permissions("OP_READ_ADMIN_INFO")]
+    #[oai(path = "/admin", method = "get")]
+    async fn macro_secured(&self) -> PlainText<String> {
+        PlainText("ADMIN_RESPONSE".to_string())
+    }
 }
 ```
 
@@ -74,6 +92,7 @@ use enums::Role::{self, ADMIN};
 use dto::User;
 
 #[poem_grants::has_role("ADMIN", type = "Role", secure = "*user_id == user.id")]
+#[poem::handler]
 async fn macro_secured(user_id: web::Path<i32>, user: web::Data<User>) -> Response {
     Response::builder().status(StatusCode::OK).body("some secured response")
 }

--- a/examples/base_example.rs
+++ b/examples/base_example.rs
@@ -10,6 +10,7 @@ const OTHER_RESPONSE: &str = "Hello!";
 
 // An example of protection via `proc-macro`
 #[poem_grants::has_permissions("OP_READ_ADMIN_INFO")]
+#[poem::handler]
 async fn macro_secured() -> Response {
     Response::builder()
         .status(StatusCode::OK)
@@ -31,6 +32,7 @@ async fn manual_secure(details: AuthDetails) -> Response {
 
 // An example of protection via `proc-macro` with secure attribute
 #[poem_grants::has_permissions("ROLE_ADMIN", secure = "*user_id == user.id")]
+#[poem::handler]
 async fn secure_with_params(user_id: web::Path<i32>, user: web::Data<&User>) -> Response {
     Response::builder()
         .status(StatusCode::OK)

--- a/examples/enum-role/src/main.rs
+++ b/examples/enum-role/src/main.rs
@@ -8,6 +8,7 @@ mod role;
 
 // `proc-macro` way require specify your type. It can be an import or a full path.
 #[poem_grants::has_any_role("ADMIN", "role::Role::MANAGER", type = "Role")]
+#[poem::handler]
 // For the `ADMIN` or `MANAGER` - endpoint will give the HTTP status 200, otherwise - 403
 async fn macro_secured() -> Response {
     Response::builder().status(StatusCode::OK).finish()

--- a/examples/jwt-auth/src/main.rs
+++ b/examples/jwt-auth/src/main.rs
@@ -10,6 +10,7 @@ mod claims;
 mod jwt_middleware;
 
 #[poem_grants::has_permissions("OP_GET_SECURED_INFO")]
+#[poem::handler]
 // For the user with permission `OP_GET_SECURED_INFO` - endpoint will give the HTTP status 200, otherwise - 403
 // You can check via cURL (for generate you own token, use `/token` handler):
 // ```sh
@@ -21,6 +22,7 @@ async fn permission_secured() -> Response {
 }
 
 #[poem_grants::has_any_role("ADMIN", "MANAGER")]
+#[poem::handler]
 // For the `ADMIN` or `MANAGER` - endpoint will give the HTTP status 200, otherwise - 403
 // You can check via cURL (for generate you own token, use `/token` handler):
 // ```sh

--- a/examples/openapi_example.rs
+++ b/examples/openapi_example.rs
@@ -1,0 +1,70 @@
+use poem::listener::TcpListener;
+use poem::{web, EndpointExt, Request, Route, Server};
+use poem_grants::permissions::{AuthDetails, PermissionsCheck};
+use poem_grants::GrantsMiddleware;
+use poem_openapi::payload::PlainText;
+use poem_openapi::{OpenApi, OpenApiService};
+
+const ROLE_ADMIN: &str = "ROLE_ADMIN";
+const ADMIN_RESPONSE: &str = "Hello Admin!";
+const OTHER_RESPONSE: &str = "Hello!";
+
+struct Api;
+
+#[poem_grants::open_api]
+#[OpenApi]
+impl Api {
+    // An example of protection via `proc-macro`
+    #[has_permissions("OP_READ_ADMIN_INFO")]
+    #[oai(path = "/admin", method = "get")]
+    async fn macro_secured(&self) -> PlainText<String> {
+        PlainText(ADMIN_RESPONSE.to_string())
+    }
+
+    // An example of programmable protection
+    #[oai(path = "/", method = "get")]
+    async fn manual_secure(&self, details: AuthDetails) -> PlainText<String> {
+        if details.has_permission(ROLE_ADMIN) {
+            return PlainText(ADMIN_RESPONSE.to_string());
+        }
+        PlainText(OTHER_RESPONSE.to_string())
+    }
+
+    // An example of protection via `proc-macro` with secure attribute
+    #[has_permissions("ROLE_ADMIN", secure = "*user_id == user.id")]
+    #[oai(path = "/resource/:user_id", method = "get")]
+    async fn secure_with_params(
+        &self,
+        user_id: web::Path<i32>,
+        user: web::Data<&User>,
+    ) -> PlainText<String> {
+        PlainText(ADMIN_RESPONSE.to_string())
+    }
+}
+
+struct User {
+    id: i32,
+}
+
+#[tokio::main]
+// Sample application with grant protection based on extracting by your custom function
+async fn main() -> Result<(), std::io::Error> {
+    let api_service = OpenApiService::new(Api, "Poem OpenApi + poem-grants", "1.0")
+        .server("http://localhost:8081/");
+    let app = Route::new().nest(
+        "/",
+        api_service.with(GrantsMiddleware::with_extractor(extract)),
+    );
+    Server::new(TcpListener::bind("127.0.0.1:8081"))
+        .run(app)
+        .await
+}
+
+// You can use both `&Request` and `&mut Request`
+async fn extract(_req: &mut Request) -> poem::Result<Vec<String>> {
+    // Here is a place for your code to get user permissions/grants/permissions from a request
+    // For example from a token or database
+
+    // Stub example
+    Ok(vec![ROLE_ADMIN.to_string()])
+}

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poem-grants-proc-macro"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 authors = ["DDtKey <ddttkey@gmail.com>"]
 description = "A proc-macro way to validate user permissions for `poem-grants` crate."
 repository = "https://github.com/DDtKey/poem-grants"
@@ -20,4 +20,4 @@ syn = { version = "1.0", features = ["full", "derive", "extra-traits"] }
 
 [dev-dependencies]
 poem = "1"
-poem-grants =  { path = "../" }
+poem-grants =  { path = ".." }

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -1,9 +1,9 @@
 extern crate proc_macro;
 use proc_macro::TokenStream;
 use quote::ToTokens;
-use syn::{parse_macro_input, AttributeArgs, ItemFn};
+use syn::{parse_macro_input, AttributeArgs, ImplItem, ImplItemMethod, ItemFn, ItemImpl, Meta};
 
-use crate::expand::HasPermissions;
+use crate::expand::{FnType, ProtectEndpoint};
 
 mod expand;
 
@@ -13,11 +13,20 @@ const HAS_ANY_AUTHORITY: &str = "has_any_permission";
 const HAS_ROLES: &str = "has_roles";
 const HAS_ANY_ROLE: &str = "has_any_role";
 
+macro_rules! unwrap_result {
+    ($result:expr) => {
+        match $result {
+            Ok(result) => result,
+            Err(err) => return syn::Error::from(err).to_compile_error().into(),
+        }
+    };
+}
+
 /// Macro to сheck that the user has all the specified permissions.
 /// Allow to add a conditional restriction based on handlers parameters.
 /// Add the `secure` attribute followed by the the boolean expression to validate based on parameters
 ///
-/// Attention: these macros already automatically generate an endpoint for the poem (`[poem::handler]`)
+/// Attention: these macros have to be above of (`[poem::handler]`) or `oai`
 ///
 /// Also you can use you own types instead of Strings, just add `type` attribute with path to type
 /// # Examples
@@ -26,6 +35,7 @@ const HAS_ANY_ROLE: &str = "has_any_role";
 ///
 /// // User should be ADMIN with OP_GET_SECRET permission
 /// #[poem_grants::has_permissions["ROLE_ADMIN", "OP_GET_SECRET"]]
+/// #[poem::handler]
 /// async fn macro_secured() -> Response {
 ///     Response::builder().status(StatusCode::OK).body("some secured info")
 /// }
@@ -34,12 +44,14 @@ const HAS_ANY_ROLE: &str = "has_any_role";
 /// // to the path parameter {user_id}
 /// struct User {id: i32}
 /// #[poem_grants::has_permissions["ROLE_ADMIN", "OP_GET_SECRET", secure="*user_id == user.id"]]
+/// #[poem::handler]
 /// async fn macro_secured_params(user_id: web::Path<i32>, user: web::Data<User>) -> Response {
 ///     Response::builder().status(StatusCode::OK).body("some secured info with user_id path equal to user.id")
 ///}
 ///
 /// // User must have MyPermissionEnum::OP_GET_SECRET (you own enum example)
 /// #[poem_grants::has_permissions["OP_GET_SECRET", type = "MyPermissionEnum"]]
+/// #[poem::handler]
 /// async fn macro_enum_secured() -> Response {
 ///     Response::builder().status(StatusCode::OK).body("some secured info")
 /// }
@@ -58,6 +70,7 @@ pub fn has_permissions(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// // User should be ADMIN or MANAGER
 /// #[poem_grants::has_any_permission["ROLE_ADMIN", "ROLE_MANAGER"]]
+/// #[poem::handler]
 /// async fn macro_secured() -> Response {
 ///     Response::builder().status(StatusCode::OK).body("some secured info")
 /// }
@@ -76,6 +89,7 @@ pub fn has_any_permission(args: TokenStream, input: TokenStream) -> TokenStream 
 ///
 /// // User should be ADMIN and MANAGER
 /// #[poem_grants::has_roles["ADMIN", "MANAGER"]]
+/// #[poem::handler]
 /// async fn macro_secured() -> Response {
 ///     Response::builder().status(StatusCode::OK).body("some secured info")
 /// }
@@ -94,6 +108,7 @@ pub fn has_roles(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// // User should be ADMIN or MANAGER
 /// #[poem_grants::has_any_role["ADMIN", "MANAGER"]]
+/// #[poem::handler]
 /// async fn macro_secured() -> Response {
 ///     Response::builder().status(StatusCode::OK).body("some secured info")
 /// }
@@ -107,8 +122,90 @@ fn check_permissions(check_fn_name: &str, args: TokenStream, input: TokenStream)
     let args = parse_macro_input!(args as AttributeArgs);
     let func = parse_macro_input!(input as ItemFn);
 
-    match HasPermissions::new(check_fn_name, args, func) {
-        Ok(has_permissions) => has_permissions.into_token_stream().into(),
-        Err(err) => err.to_compile_error().into(),
+    unwrap_result!(ProtectEndpoint::new(check_fn_name, args, FnType::Fn(func)))
+        .into_token_stream()
+        .into()
+}
+
+/// Macro for `poem-openapi` support
+/// Add macro `#[poem_grants::open_api]` above of `#[poem_openapi::OpenApi]` and mark all needed methods with necessary security-methods:
+/// One of [`has_permissions`, `has_any_permission`, `has_roles`, `has_any_role`]
+///
+/// # Examples
+/// ```
+/// use poem_openapi::payload::PlainText;
+///
+/// struct Api;
+///
+/// #[poem_grants::open_api]
+/// #[poem_openapi::OpenApi]
+/// impl Api {
+///     // An example of protection via `proc-macro`.
+///     // Just use the necessary name of macro provided by `poem-grants` without crate-name:
+///     #[has_permissions("OP_READ_ADMIN_INFO")]
+///     #[oai(path = "/admin", method = "get")]
+///     async fn macro_secured(&self) -> PlainText<String> {
+///         PlainText("ADMIN_RESPONSE".to_string())
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn open_api(_args: TokenStream, input: TokenStream) -> TokenStream {
+    // let args = parse_macro_input!(args as AttributeArgs);
+    let mut item_impl = parse_macro_input!(input as ItemImpl);
+    let mut methods = Vec::new();
+    for (idx, item) in item_impl.items.iter().enumerate() {
+        if let ImplItem::Method(method) = item {
+            for (attr_idx, attr) in method
+                .attrs
+                .iter()
+                .filter(|attr| {
+                    attr.path.is_ident(HAS_ANY_AUTHORITY)
+                        || attr.path.is_ident(HAS_AUTHORITIES)
+                        || attr.path.is_ident(HAS_ANY_ROLE)
+                        || attr.path.is_ident(HAS_ROLES)
+                })
+                .enumerate()
+            {
+                let args = match unwrap_result!(attr.parse_meta()) {
+                    Meta::List(list) => list.nested.into_iter().collect::<Vec<syn::NestedMeta>>(),
+                    _ => {
+                        return syn::Error::new_spanned(
+                            attr,
+                            "Expected endpoint-attribute to be a list",
+                        )
+                        .to_compile_error()
+                        .into()
+                    }
+                };
+
+                let generated = unwrap_result!(ProtectEndpoint::new(
+                    &attr
+                        .path
+                        .get_ident()
+                        .expect("validated by condition above")
+                        .to_string(),
+                    args,
+                    FnType::Method(method.clone()),
+                ))
+                .into_token_stream()
+                .into();
+
+                let mut gen_method = parse_macro_input!(generated as ImplItemMethod);
+                gen_method.attrs.remove(attr_idx);
+
+                methods.push((idx, gen_method));
+            }
+        }
     }
+
+    for (idx, method) in methods {
+        let _ = std::mem::replace(&mut item_impl.items[idx], ImplItem::Method(method));
+    }
+
+    let res = quote::quote! {
+        #item_impl
+    };
+
+    res.into()
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
-use poem::error::ResponseError;
-use poem::http::StatusCode;
+use poem::error::{Forbidden, Unauthorized};
 
 #[derive(Debug, thiserror::Error)]
 pub enum AccessError {
@@ -9,11 +8,11 @@ pub enum AccessError {
     ForbiddenRequest,
 }
 
-impl ResponseError for AccessError {
-    fn status(&self) -> StatusCode {
-        match self {
-            AccessError::UnauthorizedRequest => StatusCode::UNAUTHORIZED,
-            AccessError::ForbiddenRequest => StatusCode::FORBIDDEN,
+impl From<AccessError> for poem::Error {
+    fn from(value: AccessError) -> Self {
+        match value {
+            e @ AccessError::UnauthorizedRequest => Unauthorized(e),
+            e @ AccessError::ForbiddenRequest => Forbidden(e),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub use middleware::GrantsMiddleware;
 ///
 /// // User should be ADMIN with OP_GET_SECRET permission
 /// #[poem_grants::has_permissions["ROLE_ADMIN", "OP_GET_SECRET"]]
+/// #[poem::handler]
 /// async fn macro_secured() -> Response {
 ///     Response::builder().status(StatusCode::OK).body("some secured info")
 /// }
@@ -36,12 +37,14 @@ pub use middleware::GrantsMiddleware;
 /// // Role - is permission with prefix "ROLE_".
 /// // User should be ADMIN and MANAGER
 /// #[poem_grants::has_roles["ADMIN", "MANAGER"]]
+/// #[poem::handler]
 /// async fn role_macro_secured() -> Response {
 ///     Response::builder().status(StatusCode::OK).body("some secured info")
 /// }
 ///
 /// // Additional security condition to ensure the protection of the endpoint
 /// #[poem_grants::has_roles("USER", secure = "*user_id == user.id")]
+/// #[poem::handler]
 /// async fn role_macro_secured_with_params(user_id: web::Path<i32>, user: web::Data<&User>) -> Response {
 ///     Response::builder().status(StatusCode::OK).body("some secured info with parameters")
 /// }
@@ -49,6 +52,7 @@ pub use middleware::GrantsMiddleware;
 ///
 /// // You own type is also supported (need to configure middleware for this type as well):
 /// #[poem_grants::has_roles["Role::Admin", "Role::Manager", type = "Role"]]
+/// #[poem::handler]
 /// async fn role_enum_macro_secured() -> Response {
 ///     Response::builder().status(StatusCode::OK).body("some secured info")
 /// }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -34,6 +34,7 @@ use std::sync::Arc;
 /// // `has_permissions` is one of options to validate permissions.
 /// // `proc-macro` crate has additional features, like ABAC security and custom types. See examples and `proc-macro` crate docs.
 /// #[poem_grants::has_permissions("ROLE_ADMIN")]
+/// #[poem::handler]
 /// async fn you_service() -> poem::Response {
 ///     Response::builder().status(StatusCode::OK).finish()
 /// }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -50,7 +50,7 @@ pub async fn enum_extract(req: &mut Request) -> poem::Result<Vec<Role>> {
 }
 
 pub async fn test_body(resp: TestResponse, expected_body: &str) {
-    let body = resp.into_body().into_string().await.unwrap();
+    let body = resp.0.into_body().into_string().await.unwrap();
 
     assert_eq!(expected_body, &body);
 }

--- a/tests/proc_macro/different_fn_types.rs
+++ b/tests/proc_macro/different_fn_types.rs
@@ -9,11 +9,13 @@ use poem_grants::{has_roles, GrantsMiddleware};
 use serde::{Deserialize, Serialize};
 
 #[has_roles("ADMIN")]
+#[poem::handler]
 async fn http_response() -> Response {
     Response::builder().status(StatusCode::OK).finish()
 }
 
 #[has_roles("ADMIN")]
+#[poem::handler]
 async fn str_response() -> &'static str {
     "Hi!"
 }
@@ -24,16 +26,19 @@ struct User {
 }
 
 #[has_roles("ADMIN", secure = "*user_id == user.id")]
+#[poem::handler]
 async fn secure_user_id(user_id: Path<i32>, user: Json<User>) -> &'static str {
     "Hi!"
 }
 
 #[has_roles("ADMIN")]
+#[poem::handler]
 async fn return_response() -> &'static str {
     return "Hi!";
 }
 
 #[has_roles("ADMIN")]
+#[poem::handler]
 async fn result_response(
     payload: Query<common::NamePayload>,
 ) -> poem::Result<String, MethodNotAllowedError> {

--- a/tests/proc_macro/type_feature.rs
+++ b/tests/proc_macro/type_feature.rs
@@ -8,18 +8,21 @@ use poem_grants::{has_roles, GrantsMiddleware};
 
 // Using imported custom type (in `use` section)
 #[has_roles("ADMIN", type = "Role")]
+#[poem::handler]
 async fn imported_path_enum_secure() -> Response {
     Response::builder().status(StatusCode::OK).finish()
 }
 
 // Using a full path to a custom type (enum)
 #[has_roles("crate::common::Role::ADMIN", type = "crate::common::Role")]
+#[poem::handler]
 async fn full_path_enum_secure() -> Response {
     Response::builder().status(StatusCode::OK).finish()
 }
 
 // Incorrect endpoint security without Type specification
 #[has_roles("ADMIN")]
+#[poem::handler]
 async fn incorrect_enum_secure() -> Response {
     Response::builder().status(StatusCode::OK).finish()
 }


### PR DESCRIPTION
It's too straightforward implementation to support `poem-openapi`. 
It's ready-to-use solution, but I decided to keep it in `beta` because of:

I'm gonna refactor `{framework}-grants` crates to unify it and introduce several additional features. So implementation will be refactored and improved soon. But I wanted to provide this functionality now anyway, because the update will be as a breaking change.

It includes (but not only):
- Merge repos & use workspace to share some code & crates
- Refactor macro-generation, use [darling](https://crates.io/crates/darling)
- Support for combined conditions like: `any( all("TEST_PERMISSION", role("ADMIN"),  role("SUPERUSER") )`


Closes #2 