### PR TITLE
fix(openapi):`poem-grants` attributes removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [v1.0.0-beta.3] - 2023-06-19
+### Changed
+- Fix of proc-macro attributes deletion #5
+
 ## [v1.0.0-beta.2] - 2023-04-02
 ### Added
 - Support of `poem-openapi` #3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poem-grants"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 authors = ["DDtKey <ddttkey@gmail.com>"]
 description = " Authorization extension for `poem` to validate user permissions "
 repository = "https://github.com/DDtKey/poem-grants"
@@ -21,7 +21,7 @@ macro-check = ["poem-grants-proc-macro"]
 
 [dependencies]
 poem = "1"
-poem-grants-proc-macro = { path = "./proc-macro", version = "1.0.0-beta.2", optional = true }
+poem-grants-proc-macro = { path = "./proc-macro", version = "1.0.0-beta.3", optional = true }
 thiserror = "1"
 
 [dev-dependencies]

--- a/examples/openapi_example.rs
+++ b/examples/openapi_example.rs
@@ -15,6 +15,7 @@ struct Api;
 #[OpenApi]
 impl Api {
     // An example of protection via `proc-macro`
+    /// Documentation comment for `openapi` description works expected
     #[has_permissions("OP_READ_ADMIN_INFO")]
     #[oai(path = "/admin", method = "get")]
     async fn macro_secured(&self) -> PlainText<String> {

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poem-grants-proc-macro"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 authors = ["DDtKey <ddttkey@gmail.com>"]
 description = "A proc-macro way to validate user permissions for `poem-grants` crate."
 repository = "https://github.com/DDtKey/poem-grants"


### PR DESCRIPTION
#### Description:

Removal of attributes was wrong, and it was possible to remove relevant attribute, like doc-comment.

#### Checklist:

- [x] This PR has been added to [CHANGELOG.md](https://github.com/DDtKey/poem-grants/blob/main/CHANGELOG.md) (to [Unreleased] section);

Closes #4
